### PR TITLE
Added `with` TestCases to "Variable Access" Benchmark

### DIFF
--- a/scripts/GM_Benchmark/GM_Benchmark.gml
+++ b/scripts/GM_Benchmark/GM_Benchmark.gml
@@ -414,7 +414,14 @@ Benchmarks = [
             repeat (iterations) {
                 var val = local;
             }
-        })
+        }), new TestCase("with", function(iterations) {
+			var struct = { x: 0 };
+			repeat(iterations) {
+				with(struct) {
+					var val = x;
+				}
+			}
+		})
     ]),
     #endregion
     

--- a/scripts/GM_Benchmark/GM_Benchmark.gml
+++ b/scripts/GM_Benchmark/GM_Benchmark.gml
@@ -414,10 +414,17 @@ Benchmarks = [
             repeat (iterations) {
                 var val = local;
             }
-        }), new TestCase("with", function(iterations) {
+        }), new TestCase("with (inside loop)", function(iterations) {
 			var struct = { x: 0 };
 			repeat(iterations) {
 				with(struct) {
+					var val = x;
+				}
+			}
+		}), new TestCase("with (wrapped around loop)", function(iterations) {
+			var struct = { x: 0 };
+			with(struct) {
+				repeat(iterations) {
 					var val = x;
 				}
 			}

--- a/scripts/GM_Benchmark/GM_Benchmark.gml
+++ b/scripts/GM_Benchmark/GM_Benchmark.gml
@@ -411,7 +411,6 @@ Benchmarks = [
             }
         }), new TestCase("local", function(iterations) {
             var local = 0;
-            var hash = variable_get_hash("x");
             repeat (iterations) {
                 var val = local;
             }


### PR DESCRIPTION
I was curious if using `with(struct)` would give you any performance difference in variable accessing. I thought it would be slow (and it was) but I had thought that maybe putting the `with` *outside* of the loop would give a nominal performance increase. And I was correct :)

<img width="897" height="829" alt="The new TestCases" src="https://github.com/user-attachments/assets/577340c6-7b56-4ec6-84c1-3b39c83c7601" />

<img width="498" height="244" alt="image" src="https://github.com/user-attachments/assets/e6d970f9-df08-4283-8054-cd597dcbd00f" />

I think this is worth adding to the benchmark, since some don't even realize you can even do `with(struct)` and it seems to be the fastest struct accessor (when iterating over something multiple times like this) 😅 

PS: This PR also removes an unnecessary call to `variable_get_hash()` in the "local" TestCase